### PR TITLE
Add a random slug to the Slack view ID

### DIFF
--- a/app/lib/slack_client/views/puzzle_form.rb
+++ b/app/lib/slack_client/views/puzzle_form.rb
@@ -27,7 +27,7 @@ module SlackClient
           end
         end
 
-        Slack::BlockKit.modal blocks: blocks, external_id: "puzzle_form", title: "Suggest a Puzzle" do |modal|
+        Slack::BlockKit.modal blocks: blocks, external_id: "puzzle_form__#{SecureRandom.hex(6)}", title: "Suggest a Puzzle" do |modal|
           modal.submit text: "Submit"
           modal.close text: "Close"
         end.as_json


### PR DESCRIPTION
Add a random slug to the Slack external view ID to prevent duplicate external ID issues when puzzles are submitted via Slack.