### PR TITLE
Add log-level control through env var

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,6 +4,7 @@ class ApplicationJob < ActiveJob::Base
   def bot
     @bot ||= Discord::Bot.configure do |config|
       config.token = ENV.fetch("DISCORD_BOT_TOKEN", "")
+      config.log_mode = ENV.fetch("DISCORD_LOG_MODE", "normal").to_sym
     end
   end
 end

--- a/app/lib/discord/bot.rb
+++ b/app/lib/discord/bot.rb
@@ -18,10 +18,9 @@ module Discord
     delegate :send_message, to: :bot
 
     def initialize(configuration)
-      @bot = Discordrb::Bot.new(token: configuration.token)
+      @bot = Discordrb::Bot.new(token: configuration.token, log_mode: configuration.log_mode)
       @bot.ready do
         Rails.logger.info "✅ Bot is online and connected to Discord!"
-        puts "✅ Bot is online and connected to Discord!"
         setup
       end
     end

--- a/app/lib/discord/configuration.rb
+++ b/app/lib/discord/configuration.rb
@@ -5,6 +5,7 @@ module Discord
 
     def initialize
       @token = nil
+      @log_mode = :normal
     end
   end
 end

--- a/lib/tasks/discord.rake
+++ b/lib/tasks/discord.rake
@@ -26,6 +26,7 @@ def bot
   @bot ||= begin
     bot_wrapper = Discord::Bot.configure do |config|
       config.token = ENV.fetch("DISCORD_BOT_TOKEN")
+      config.log_mode = ENV.fetch("DISCORD_LOG_MODE", "normal").to_sym
     end
     bot_wrapper.bot
   end


### PR DESCRIPTION
This PR adds log-level control for the Discord bot through an environment variable.
Logs will default to "normal" level.

This is a small PR to make debugging easier when needed.
