### PR TITLE
One more task to send a daily puzzle manually if needed

### DIFF
--- a/lib/tasks/discord.rake
+++ b/lib/tasks/discord.rake
@@ -4,6 +4,11 @@ namespace :discord do
     bot.run
   end
 
+  desc "Sends a daily puzzle. Useful for days when the approved puzzles where at 0 when the cron job ran."
+  task new_puzzle: :environment do
+    DailyPuzzleJob.perform_now
+  end
+
   desc "Clear all globally registered bot commands and re-register them"
   task reset_commands: :environment do
     # Fetch and delete all existing commands


### PR DESCRIPTION
Hi there,

We have seen this situation when we have no more approved puzzles and we need to run this command manually. So this would enable us to do something like this:

```
heroku run rake discord:new_puzzle
```

It would save us a couple of steps if we need to manually send out a puzzle to Discord servers...

What do you think? 