### PR TITLE
25: Use simple_format to display puzzle questions

### DIFF
--- a/app/views/puzzles/_puzzles_table.html.erb
+++ b/app/views/puzzles/_puzzles_table.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% puzzles.each do |puzzle| %>
       <tr id="<%= dom_id(puzzle) %>">
-        <td><%= puzzle.question %></td>
+        <td><%= simple_format(puzzle.question) %></td>
         <td><%= puzzle.answer %></td>
         <td><%= puzzle.explanation %></td>
         <td>


### PR DESCRIPTION
Render puzzle question with line breaks

Use Rails' simple_format helper to display puzzle questions with preserved line breaks in the table view. This improves readability for questions containing newline characters from the database.

See: https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html

### QA Notes
- Edit a puzzle's question text (by adding newlines \n)
- Ensure all puzzles display as expected (with newlines where they are expected)

PR fixes: https://github.com/fastruby/ruby_or_rails/issues/25