### PR TITLE
Use simple_format on edit and increase text_area

### DIFF
--- a/app/views/puzzles/_form.html.erb
+++ b/app/views/puzzles/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: puzzle do |f| %>
   <div class="modal-area">
     <%= f.label :question %>
-    <%= f.text_area :question, class: puzzle.errors[:question].any? ? "error" : "" %>
+    <%= f.text_area :question, class: puzzle.errors[:question].any? ? "error" : "", rows: 10, cols: 40 %>
     <% if puzzle.errors[:question].any? %>
       <div class="field-error"><%= puzzle.errors[:question].first %></div>
     <% end %>
@@ -21,7 +21,7 @@
 
   <div class="modal-area">
     <%= f.label :explanation %>
-    <%= f.text_area :explanation %>
+    <%= f.text_area :explanation, rows: 10, cols: 40 %>
   </div>
 
   <div class="modal-area">

--- a/app/views/puzzles/update.turbo_stream.erb
+++ b/app/views/puzzles/update.turbo_stream.erb
@@ -1,7 +1,7 @@
 <turbo-stream action="replace" target="<%= dom_id(@puzzle) %>">
   <template>
     <tr id="<%= dom_id(@puzzle) %>">
-      <td><%= @puzzle.question %></td>
+      <td><%= simple_format(@puzzle.question) %></td>
       <td><%= @puzzle.answer %></td>
       <td><%= @puzzle.explanation %></td>
       <td>


### PR DESCRIPTION
This PR fixes the issues https://github.com/fastruby/ruby_or_rails/issues/42 and #41.

<img width="715" height="760" alt="Screenshot 2025-10-15 at 8 09 42 am" src="https://github.com/user-attachments/assets/c063bb39-ec66-4b00-a869-752f148571f0" />
