### PR TITLE
IIRR-32: Add feature to filter the archived list by low success rate

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -239,3 +239,8 @@ input.error, textarea.error {
   background-color: yellow;
   color: black;
 }
+
+section.filters {
+  text-align: start;
+  padding-inline-start: 1rem;
+}

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -4,6 +4,7 @@ class PuzzlesController < ApplicationController
     @approved_puzzles = Puzzle.approved
     @rejected_puzzles = Puzzle.rejected
     @archived_puzzles = Puzzle.archived
+    @archived_puzzles = @archived_puzzles.only_low_success_rate if params[:low_success_rate]
   end
 
   def edit

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -10,9 +10,15 @@ class Puzzle < ApplicationRecord
   scope :archived, -> { where(state: :archived).order(sent_at: :desc) }
 
   def correct_answer_percentage
-    total = answers.count
+    total = answers.size
     return 0 if total.zero?
 
-    (answers.where(is_correct: true).count * 100.0 / total).round(1)
+    correct_count = answers.loaded ? answers.select(&:is_correct).count : answers.where(is_correct: true).count
+
+    (correct_count * 100.0 / total).round(1)
+  end
+
+  def self.only_low_success_rate
+    includes(:answers).to_a.select { |ans| ans.correct_answer_percentage <= 80 }
   end
 end

--- a/app/views/puzzles/index.html.erb
+++ b/app/views/puzzles/index.html.erb
@@ -16,4 +16,9 @@
 
 <h1>Archive Puzzles - Total: <%= @archived_puzzles.length %></h1>
 <p>These puzzles have already been sent to the users.</p>
+<section class="filters">
+  <label>Filters:</label>
+  <br>
+  <%= link_to "Show low success rate only", url_for(low_success_rate: true) %>
+</section>
 <%= render partial: 'puzzles_table', locals: { puzzles: @archived_puzzles, actions: :archived } %>

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,47 @@
+answer1:
+  puzzle: archived_low_rate
+  user: user1
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer2:
+  puzzle: archived_low_rate
+  user: user2
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer3:
+  puzzle: archived_low_rate
+  user: user3
+  is_correct: false
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer4:
+  puzzle: archived_low_rate
+  user: user4
+  is_correct: false
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer5:
+  puzzle: archived_high_rate
+  user: user1
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer6:
+  puzzle: archived_high_rate
+  user: user2
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer7:
+  puzzle: archived_high_rate
+  user: user3
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>
+
+answer8:
+  puzzle: archived_high_rate
+  user: user4
+  is_correct: true
+  server_id: <%= ActiveRecord::FixtureSet::identify(:server1) %>

--- a/test/fixtures/puzzles.yml
+++ b/test/fixtures/puzzles.yml
@@ -4,7 +4,6 @@ one:
   explanation: "This is a test puzzle"
   link: "https://example.com"
   state: "approved"
-  sent_at: <%= 1.day.ago %>
   suggested_by: "test_user"
 
 two:
@@ -13,5 +12,22 @@ two:
   explanation: "This is a test puzzle 2"
   link: ""
   state: "pending"
+  suggested_by: "test_user"
+
+archived_low_rate:
+  question: "Some question with low answer rate"
+  answer: "ruby"
+  explanation: "This is a question with low answer rate"
+  link: ""
+  state: "archived"
+  sent_at: <%= 2.days.ago %>
+  suggested_by: "test_user"
+
+archived_high_rate:
+  question: "Some question with high answer rate"
+  answer: "ruby"
+  explanation: "This is a question with high answer rate"
+  link: ""
+  state: "archived"
   sent_at: <%= 2.days.ago %>
   suggested_by: "test_user"

--- a/test/fixtures/servers.yml
+++ b/test/fixtures/servers.yml
@@ -1,0 +1,3 @@
+server1:
+  name: Server1
+  server_id: id1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,19 @@
+user1:
+  role: 1
+  user_id: id1
+  username: user1
+
+user2:
+  role: 1
+  user_id: id2
+  username: user2
+
+user3:
+  role: 1
+  user_id: id3
+  username: user3
+
+user4:
+  role: 1
+  user_id: id4
+  username: user4

--- a/test/models/puzzle_test.rb
+++ b/test/models/puzzle_test.rb
@@ -49,4 +49,14 @@ class PuzzleTest < ActiveSupport::TestCase
   test "has many answers" do
     assert_respond_to Puzzle.new, :answers
   end
+
+  test "only_low_success_rate includes only puzzles with less than or equal 80%" do
+    puzzles = Puzzle.archived
+    assert_includes puzzles, puzzles(:archived_low_rate)
+    assert_includes puzzles, puzzles(:archived_high_rate)
+
+    puzzles = Puzzle.archived.only_low_success_rate
+    assert_includes puzzles, puzzles(:archived_low_rate)
+    assert_not_includes puzzles, puzzles(:archived_high_rate)
+  end
 end


### PR DESCRIPTION
This PR adds a new filter for the Archived table to only show puzzles with a success answer rate lower than or equal to 80%.

I also updated the `correct_answer_percentage` to reuse the already loaded association when possible to avoid extra DB queries.