### PR TITLE
[IIRR-39] Add archived puzzle seeds for low success rate filter testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,7 +148,7 @@ users = [
   { user_id: 110, username: "user10", role: "member" }
 ]
 
-users.each_with_index do |user_data, user_idx|
+users.each do |user_data|
   user = User.find_or_create_by!(user_id: user_data[:user_id]) do |u|
     u.username = user_data[:username]
     u.role = user_data[:role]
@@ -156,22 +156,26 @@ users.each_with_index do |user_data, user_idx|
 
   # Associate user with the server if not already linked
   user.servers << server unless user.servers.include?(server)
+end
 
-  # Seed answers for archived puzzles so correct_answer_percentage has data.
-  # Real users only answer puzzles after they've been sent (archived state).
-  # Each puzzle's success_rate is deterministic: user_idx < rate/10 means correct,
-  # so a rate of 20 yields exactly 2/10 correct, 80 yields 8/10, etc.
-  Puzzle.archived.each do |puzzle|
-    base_question = puzzle.original_puzzle&.question || puzzle.question
-    rate = success_rate_by_question.fetch(base_question, 50)
+# ====== Seed answers for archived puzzles ======
+# Real users only answer puzzles after they've been sent (archived state).
+# For each archived puzzle, mark the first `success_rate / 10` users correct
+# and the rest incorrect, so each puzzle hits its target rate exactly.
+server_users = server.users.order(:id)
 
+Puzzle.archived.each do |puzzle|
+  base_question = puzzle.original_puzzle&.question || puzzle.question
+  correct_count = success_rate_by_question.fetch(base_question, 50) / 10
+
+  server_users.each_with_index do |user, idx|
     Answer.find_or_create_by!(
       user_id: user.id,
       puzzle_id: puzzle.id,
       server_id: server.id
     ) do |answer|
       answer.choice = [ "ruby", "rails" ].sample
-      answer.is_correct = user_idx < (rate / 10)
+      answer.is_correct = idx < correct_count
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,6 +36,71 @@ puzzles.each do |p|
   end
 end
 
+# ====== Create Archived (already sent) Puzzle records ======
+archived_puzzles = [
+  {
+    question: "Ruby or Rails provided this method? before_action :authenticate_user!",
+    answer: :rails,
+    explanation: "`before_action` is a Rails callback defined in `ActionController::Callbacks`. It runs specified methods before controller actions.",
+    sent_at: 7.days.ago,
+    high_success: false
+  },
+  {
+    question: "Ruby or Rails provided this method? 42.times { puts 'hello' }",
+    answer: :ruby,
+    explanation: "`Integer#times` is a core Ruby method that iterates a block a specified number of times.",
+    sent_at: 6.days.ago,
+    high_success: false
+  },
+  {
+    question: "Ruby or Rails provided this method? User.where(active: true).order(:name)",
+    answer: :rails,
+    explanation: "`where` and `order` are ActiveRecord query methods provided by Rails to build SQL queries.",
+    sent_at: 5.days.ago,
+    high_success: false
+  },
+  {
+    question: "Ruby or Rails provided this method? 'hello world'.split(' ')",
+    answer: :ruby,
+    explanation: "`String#split` is a core Ruby method that divides a string into an array based on a delimiter.",
+    sent_at: 4.days.ago,
+    high_success: false
+  },
+  {
+    question: "Ruby or Rails provided this method? flash[:notice] = 'Saved!'",
+    answer: :rails,
+    explanation: "`flash` is a Rails feature provided by `ActionDispatch::Flash` for passing messages between requests.",
+    sent_at: 3.days.ago,
+    high_success: false
+  },
+  # high success rate puzzles (9/10 correct = 90%) -- should NOT appear in low success rate filter
+  {
+    question: "Ruby or Rails provided this method? [1, 2, 3].reduce(:+)",
+    answer: :ruby,
+    explanation: "`Enumerable#reduce` (also `inject`) is a core Ruby method that combines elements using a binary operation.",
+    sent_at: 2.days.ago,
+    high_success: true
+  },
+  {
+    question: "Ruby or Rails provided this method? validates :email, presence: true, uniqueness: true",
+    answer: :rails,
+    explanation: "`validates` is an ActiveModel/ActiveRecord method from Rails that adds validation rules to models.",
+    sent_at: 1.day.ago,
+    high_success: true
+  }
+]
+
+high_success_questions = archived_puzzles.select { |p| p[:high_success] }.map { |p| p[:question] }
+
+archived_puzzles.each do |p|
+  Puzzle.find_or_create_by!(question: p[:question]) do |puzzle|
+    puzzle.answer = p[:answer]
+    puzzle.explanation = p[:explanation]
+    puzzle.state = :archived
+    puzzle.sent_at = p[:sent_at]
+  end
+end
+
 # ====== Create the Server ======
 server = Server.find_or_create_by!(server_id: 1179555097060061245) do |s|
   s.name = "OmbuTest"
@@ -55,7 +120,7 @@ users = [
   { user_id: 110, username: "user10", role: "member" }
 ]
 
-users.each do |user_data|
+users.each_with_index do |user_data, user_idx|
   user = User.find_or_create_by!(user_id: user_data[:user_id]) do |u|
     u.username = user_data[:username]
     u.role = user_data[:role]
@@ -64,10 +129,12 @@ users.each do |user_data|
   # Associate user with the server if not already linked
   user.servers << server unless user.servers.include?(server)
 
-  # Seed random answers for this user if they have none
+  # Seed random answers for approved puzzles if user has none
   if user.answers.where(server_id: server.id).empty?
     3.times do
-      puzzle = Puzzle.all.sample
+      puzzle = Puzzle.approved.sample
+      next unless puzzle
+
       Answer.find_or_create_by!(
         user_id: user.id,
         puzzle_id: puzzle.id,
@@ -76,6 +143,20 @@ users.each do |user_data|
         answer.choice = [ "ruby", "rails" ].sample
         answer.is_correct = [ true, false ].sample
       end
+    end
+  end
+
+  # Seed answers for archived puzzles so correct_answer_percentage has data.
+  # High-success puzzles get 9/10 correct; others get random low/mixed results.
+  Puzzle.archived.each do |puzzle|
+    is_high_success = high_success_questions.include?(puzzle.question)
+    Answer.find_or_create_by!(
+      user_id: user.id,
+      puzzle_id: puzzle.id,
+      server_id: server.id
+    ) do |answer|
+      answer.choice = [ "ruby", "rails" ].sample
+      answer.is_correct = is_high_success ? user_idx < 9 : [ true, false ].sample
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,6 +101,28 @@ archived_puzzles.each do |p|
   end
 end
 
+# ====== Clone a couple archived puzzles so the "hide cloned" filter has data ======
+cloned_source_questions = [
+  "Ruby or Rails provided this method? before_action :authenticate_user!",
+  "Ruby or Rails provided this method? User.where(active: true).order(:name)"
+]
+
+cloned_source_questions.each do |question|
+  parent = Puzzle.find_by(question: question)
+  next unless parent
+  next if Puzzle.where(original_puzzle_id: parent.id).exists?
+
+  Puzzle.create!(
+    question: parent.question,
+    answer: parent.answer,
+    explanation: parent.explanation,
+    link: parent.link,
+    suggested_by: parent.suggested_by,
+    state: :pending,
+    original_puzzle: parent
+  )
+end
+
 # ====== Create the Server ======
 server = Server.find_or_create_by!(server_id: 1179555097060061245) do |s|
   s.name = "OmbuTest"
@@ -129,24 +151,8 @@ users.each_with_index do |user_data, user_idx|
   # Associate user with the server if not already linked
   user.servers << server unless user.servers.include?(server)
 
-  # Seed random answers for approved puzzles if user has none
-  if user.answers.where(server_id: server.id).empty?
-    3.times do
-      puzzle = Puzzle.approved.sample
-      next unless puzzle
-
-      Answer.find_or_create_by!(
-        user_id: user.id,
-        puzzle_id: puzzle.id,
-        server_id: server.id
-      ) do |answer|
-        answer.choice = [ "ruby", "rails" ].sample
-        answer.is_correct = [ true, false ].sample
-      end
-    end
-  end
-
   # Seed answers for archived puzzles so correct_answer_percentage has data.
+  # Real users only answer puzzles after they've been sent (archived state).
   # High-success puzzles get 9/10 correct; others get random low/mixed results.
   Puzzle.archived.each do |puzzle|
     is_high_success = high_success_questions.include?(puzzle.question)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,9 @@
 # db/seeds.rb
 
 # ====== Create Puzzle records ======
+# Archived entries carry `sent_at` and a fixed `success_rate` (% of 10 users
+# who answer correctly). Rates <= 80 appear in the "low success rate" filter;
+# rates > 80 do not. Entries without `state` default to :pending.
 puzzles = [
   {
     question: "Ruby or Rails provided this method? Array.new(5) { |i| i * 2 }",
@@ -26,24 +29,12 @@ puzzles = [
     question: "Ruby or Rails provided this method? params[:id]",
     answer: :rails,
     explanation: "`params[:id]` is used in Rails to fetch query parameters or URL parameters in controller actions."
-  }
-]
-
-puzzles.each do |p|
-  Puzzle.find_or_create_by!(question: p[:question]) do |puzzle|
-    puzzle.answer = p[:answer]
-    puzzle.explanation = p[:explanation]
-  end
-end
-
-# ====== Create Archived (already sent) Puzzle records ======
-# Each puzzle has a fixed success_rate (% of 10 users who answer correctly).
-# Rates <= 80 appear in the "low success rate" filter; rates > 80 do not.
-archived_puzzles = [
+  },
   {
     question: "Ruby or Rails provided this method? before_action :authenticate_user!",
     answer: :rails,
     explanation: "`before_action` is a Rails callback defined in `ActionController::Callbacks`. It runs specified methods before controller actions.",
+    state: :archived,
     sent_at: 7.days.ago,
     success_rate: 20
   },
@@ -51,6 +42,7 @@ archived_puzzles = [
     question: "Ruby or Rails provided this method? 42.times { puts 'hello' }",
     answer: :ruby,
     explanation: "`Integer#times` is a core Ruby method that iterates a block a specified number of times.",
+    state: :archived,
     sent_at: 6.days.ago,
     success_rate: 40
   },
@@ -58,6 +50,7 @@ archived_puzzles = [
     question: "Ruby or Rails provided this method? User.where(active: true).order(:name)",
     answer: :rails,
     explanation: "`where` and `order` are ActiveRecord query methods provided by Rails to build SQL queries.",
+    state: :archived,
     sent_at: 5.days.ago,
     success_rate: 50
   },
@@ -65,6 +58,7 @@ archived_puzzles = [
     question: "Ruby or Rails provided this method? 'hello world'.split(' ')",
     answer: :ruby,
     explanation: "`String#split` is a core Ruby method that divides a string into an array based on a delimiter.",
+    state: :archived,
     sent_at: 4.days.ago,
     success_rate: 70
   },
@@ -72,14 +66,15 @@ archived_puzzles = [
     question: "Ruby or Rails provided this method? flash[:notice] = 'Saved!'",
     answer: :rails,
     explanation: "`flash` is a Rails feature provided by `ActionDispatch::Flash` for passing messages between requests.",
+    state: :archived,
     sent_at: 3.days.ago,
     success_rate: 80
   },
-  # high success rate puzzles -- should NOT appear in the low success rate filter (rate > 80)
   {
     question: "Ruby or Rails provided this method? [1, 2, 3].reduce(:+)",
     answer: :ruby,
     explanation: "`Enumerable#reduce` (also `inject`) is a core Ruby method that combines elements using a binary operation.",
+    state: :archived,
     sent_at: 2.days.ago,
     success_rate: 90
   },
@@ -87,18 +82,21 @@ archived_puzzles = [
     question: "Ruby or Rails provided this method? validates :email, presence: true, uniqueness: true",
     answer: :rails,
     explanation: "`validates` is an ActiveModel/ActiveRecord method from Rails that adds validation rules to models.",
+    state: :archived,
     sent_at: 1.day.ago,
     success_rate: 100
   }
 ]
 
-success_rate_by_question = archived_puzzles.to_h { |p| [ p[:question], p[:success_rate] ] }
+success_rate_by_question = puzzles.each_with_object({}) do |p, h|
+  h[p[:question]] = p[:success_rate] if p[:success_rate]
+end
 
-archived_puzzles.each do |p|
+puzzles.each do |p|
   Puzzle.find_or_create_by!(question: p[:question]) do |puzzle|
     puzzle.answer = p[:answer]
     puzzle.explanation = p[:explanation]
-    puzzle.state = :archived
+    puzzle.state = p[:state] if p[:state]
     puzzle.sent_at = p[:sent_at]
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,14 +101,17 @@ archived_puzzles.each do |p|
   end
 end
 
-# ====== Clone a couple archived puzzles so the "hide cloned" filter has data ======
-cloned_source_questions = [
-  "Ruby or Rails provided this method? before_action :authenticate_user!",
-  "Ruby or Rails provided this method? User.where(active: true).order(:name)"
+# ====== Clone a few archived puzzles so the "hide cloned" filter has data ======
+# Mix of pending and archived clones to exercise both states.
+cloned_sources = [
+  { question: "Ruby or Rails provided this method? before_action :authenticate_user!", state: :pending },
+  { question: "Ruby or Rails provided this method? User.where(active: true).order(:name)", state: :pending },
+  { question: "Ruby or Rails provided this method? 42.times { puts 'hello' }", state: :archived, sent_at: 12.hours.ago },
+  { question: "Ruby or Rails provided this method? flash[:notice] = 'Saved!'", state: :archived, sent_at: 6.hours.ago }
 ]
 
-cloned_source_questions.each do |question|
-  parent = Puzzle.find_by(question: question)
+cloned_sources.each do |source|
+  parent = Puzzle.find_by(question: source[:question])
   next unless parent
   next if Puzzle.where(original_puzzle_id: parent.id).exists?
 
@@ -118,7 +121,8 @@ cloned_source_questions.each do |question|
     explanation: parent.explanation,
     link: parent.link,
     suggested_by: parent.suggested_by,
-    state: :pending,
+    state: source[:state],
+    sent_at: source[:sent_at],
     original_puzzle: parent
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,60 +37,62 @@ puzzles.each do |p|
 end
 
 # ====== Create Archived (already sent) Puzzle records ======
+# Each puzzle has a fixed success_rate (% of 10 users who answer correctly).
+# Rates <= 80 appear in the "low success rate" filter; rates > 80 do not.
 archived_puzzles = [
   {
     question: "Ruby or Rails provided this method? before_action :authenticate_user!",
     answer: :rails,
     explanation: "`before_action` is a Rails callback defined in `ActionController::Callbacks`. It runs specified methods before controller actions.",
     sent_at: 7.days.ago,
-    high_success: false
+    success_rate: 20
   },
   {
     question: "Ruby or Rails provided this method? 42.times { puts 'hello' }",
     answer: :ruby,
     explanation: "`Integer#times` is a core Ruby method that iterates a block a specified number of times.",
     sent_at: 6.days.ago,
-    high_success: false
+    success_rate: 40
   },
   {
     question: "Ruby or Rails provided this method? User.where(active: true).order(:name)",
     answer: :rails,
     explanation: "`where` and `order` are ActiveRecord query methods provided by Rails to build SQL queries.",
     sent_at: 5.days.ago,
-    high_success: false
+    success_rate: 50
   },
   {
     question: "Ruby or Rails provided this method? 'hello world'.split(' ')",
     answer: :ruby,
     explanation: "`String#split` is a core Ruby method that divides a string into an array based on a delimiter.",
     sent_at: 4.days.ago,
-    high_success: false
+    success_rate: 70
   },
   {
     question: "Ruby or Rails provided this method? flash[:notice] = 'Saved!'",
     answer: :rails,
     explanation: "`flash` is a Rails feature provided by `ActionDispatch::Flash` for passing messages between requests.",
     sent_at: 3.days.ago,
-    high_success: false
+    success_rate: 80
   },
-  # high success rate puzzles (9/10 correct = 90%) -- should NOT appear in low success rate filter
+  # high success rate puzzles -- should NOT appear in the low success rate filter (rate > 80)
   {
     question: "Ruby or Rails provided this method? [1, 2, 3].reduce(:+)",
     answer: :ruby,
     explanation: "`Enumerable#reduce` (also `inject`) is a core Ruby method that combines elements using a binary operation.",
     sent_at: 2.days.ago,
-    high_success: true
+    success_rate: 90
   },
   {
     question: "Ruby or Rails provided this method? validates :email, presence: true, uniqueness: true",
     answer: :rails,
     explanation: "`validates` is an ActiveModel/ActiveRecord method from Rails that adds validation rules to models.",
     sent_at: 1.day.ago,
-    high_success: true
+    success_rate: 100
   }
 ]
 
-high_success_questions = archived_puzzles.select { |p| p[:high_success] }.map { |p| p[:question] }
+success_rate_by_question = archived_puzzles.to_h { |p| [ p[:question], p[:success_rate] ] }
 
 archived_puzzles.each do |p|
   Puzzle.find_or_create_by!(question: p[:question]) do |puzzle|
@@ -116,7 +118,7 @@ cloned_sources.each do |source|
   next if Puzzle.where(original_puzzle_id: parent.id).exists?
 
   Puzzle.create!(
-    question: parent.question,
+    question: "#{parent.question} (clone)",
     answer: parent.answer,
     explanation: parent.explanation,
     link: parent.link,
@@ -157,16 +159,19 @@ users.each_with_index do |user_data, user_idx|
 
   # Seed answers for archived puzzles so correct_answer_percentage has data.
   # Real users only answer puzzles after they've been sent (archived state).
-  # High-success puzzles get 9/10 correct; others get random low/mixed results.
+  # Each puzzle's success_rate is deterministic: user_idx < rate/10 means correct,
+  # so a rate of 20 yields exactly 2/10 correct, 80 yields 8/10, etc.
   Puzzle.archived.each do |puzzle|
-    is_high_success = high_success_questions.include?(puzzle.question)
+    base_question = puzzle.original_puzzle&.question || puzzle.question
+    rate = success_rate_by_question.fetch(base_question, 50)
+
     Answer.find_or_create_by!(
       user_id: user.id,
       puzzle_id: puzzle.id,
       server_id: server.id
     ) do |answer|
       answer.choice = [ "ruby", "rails" ].sample
-      answer.is_correct = is_high_success ? user_idx < 9 : [ true, false ].sample
+      answer.is_correct = user_idx < (rate / 10)
     end
   end
 end

--- a/test/jobs/daily_puzzle_job_test.rb
+++ b/test/jobs/daily_puzzle_job_test.rb
@@ -41,6 +41,8 @@ class DailyPuzzleJobTest < ActiveJob::TestCase
   end
 
   test "marks the selected puzzle as archived and sets sent_at" do
+    Puzzle.approved.where(sent_at: nil).delete_all
+
     puzzle = Puzzle.create!(
       question: "Approved unsent puzzle question",
       answer: "ruby",


### PR DESCRIPTION
https://ombulabs.atlassian.net/browse/IIRR-39

## Summary

- Adds 7 archived (already sent) puzzles to `db/seeds.rb` with deterministic success rates spanning the last 7 days
- Seeds answers for all 10 users against each archived puzzle so `correct_answer_percentage` returns real data
- Each archived puzzle has a fixed `success_rate` (20, 40, 50, 70, 80, 90, 100). The seed assigns `is_correct` via `user_idx < rate / 10`, so the resulting percentages are exact across runs
- Adds 4 cloned puzzles (2 `pending`, 2 `archived`) with `original_puzzle_id` set, so the "Hide cloned puzzles" filter from #78 has data to filter. Clone questions are suffixed with `(clone)` to make them easy to spot during manual testing
- Removes the prior block that seeded random answers against `approved` puzzles. In reality only archived puzzles can have answers, so seeding them on approved was wrong

## Context

Follow-up to #76 (low success rate filter) and #78 (hide cloned puzzles filter). Both filters need archived puzzles with known success rates and a mix of cloned/uncloned originals to be exercised locally.

Also includes a small fix to `DailyPuzzleJobTest#test_marks_the_selected_puzzle_as_archived_and_sets_sent_at`: clears any other `approved` + `sent_at: nil` puzzles before invoking the job, so the test no longer depends on which eligible puzzle the job picks at random. This was a pre-existing flake exposed once #76 removed `sent_at` from the `:one` fixture.

## Test plan

- [ ] Run `bin/rails db:seed:replant`
- [ ] Navigate to the Archived Puzzles section
- [ ] Verify 9 archived puzzles appear (7 originals + 2 archived clones suffixed with `(clone)`)
- [ ] Click "Show low success rate only" and verify only the 7 puzzles with rate ≤ 80 remain (the `reduce` 90% and `validates` 100% puzzles disappear)
- [ ] Click "Hide cloned puzzles" and verify the 4 parents that have clones are hidden from the archived table
- [ ] Combine both filters and verify the intersection behaves correctly
- [ ] Run `bin/rails test` and confirm all tests pass
