### PR TITLE
IIRR-33: Filter out cloned archived puzzles

### DIFF
--- a/app/controllers/puzzles/clones_controller.rb
+++ b/app/controllers/puzzles/clones_controller.rb
@@ -1,10 +1,9 @@
 class Puzzles::ClonesController < ApplicationController
   def create
     original_puzzle = Puzzle.find(params[:puzzle_id])
-    attributes = original_puzzle.attributes.slice("question", "answer", "explanation", "link", "suggested_by")
-    cloned_puzzle = Puzzle.new(attributes.merge(original_puzzle:, state: params.fetch(:state, "pending")))
+    cloned_puzzle = original_puzzle.clone
 
-    if cloned_puzzle.save
+    if cloned_puzzle.persisted?
       redirect_to puzzles_path, notice: "Puzzle cloned. You can now edit the new puzzle."
     else
       redirect_to puzzles_path, alert: "Failed to clone puzzle."

--- a/app/controllers/puzzles/clones_controller.rb
+++ b/app/controllers/puzzles/clones_controller.rb
@@ -1,7 +1,7 @@
 class Puzzles::ClonesController < ApplicationController
   def create
     original_puzzle = Puzzle.find(params[:puzzle_id])
-    cloned_puzzle = original_puzzle.clone
+    cloned_puzzle = original_puzzle.clone_puzzle
 
     if cloned_puzzle.persisted?
       redirect_to puzzles_path, notice: "Puzzle cloned. You can now edit the new puzzle."

--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -5,6 +5,7 @@ class PuzzlesController < ApplicationController
     @rejected_puzzles = Puzzle.rejected
     @archived_puzzles = Puzzle.archived
     @archived_puzzles = @archived_puzzles.only_low_success_rate if params[:low_success_rate]
+    @archived_puzzles = @archived_puzzles.without_cloned if params[:hide_cloned_puzzles]
   end
 
   def edit

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -18,7 +18,7 @@ class Puzzle < ApplicationRecord
     (correct_count * 100.0 / total).round(1)
   end
 
-  def clone
+  def clone_puzzle
     attrs = attributes.slice("question", "answer", "explanation", "link", "suggested_by")
     Puzzle.create(attrs.merge(original_puzzle: self, state: "pending"))
   end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -18,7 +18,18 @@ class Puzzle < ApplicationRecord
     (correct_count * 100.0 / total).round(1)
   end
 
+  def clone
+    attrs = attributes.slice("question", "answer", "explanation", "link", "suggested_by")
+    Puzzle.create(attrs.merge(original_puzzle: self, state: "pending"))
+  end
+
   def self.only_low_success_rate
-    includes(:answers).to_a.select { |ans| ans.correct_answer_percentage <= 80 }
+    low_success_rate_ids = includes(:answers).to_a.select { |ans| ans.correct_answer_percentage <= 80 }.map(&:id)
+    where(id: low_success_rate_ids)
+  end
+
+  def self.without_cloned
+    cloned_puzzles_ids = unscoped.where.not(original_puzzle_id: nil).pluck(:original_puzzle_id)
+    all.to_a.select { |puzzle| !cloned_puzzles_ids.include?(puzzle.id) }
   end
 end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -30,6 +30,6 @@ class Puzzle < ApplicationRecord
 
   def self.without_cloned
     cloned_puzzles_ids = unscoped.where.not(original_puzzle_id: nil).pluck(:original_puzzle_id)
-    all.to_a.select { |puzzle| !cloned_puzzles_ids.include?(puzzle.id) }
+    where.not(id: cloned_puzzles_ids)
   end
 end

--- a/app/views/puzzles/index.html.erb
+++ b/app/views/puzzles/index.html.erb
@@ -19,6 +19,8 @@
 <section class="filters">
   <label>Filters:</label>
   <br>
-  <%= link_to "Show low success rate only", url_for(low_success_rate: true) %>
+  <%= link_to "Show low success rate only", url_for(low_success_rate: true, hide_cloned_puzzles: params[:hide_cloned_puzzles]) %>
+  <br>
+  <%= link_to "Hide cloned puzzles", url_for(hide_cloned_puzzles: true, low_success_rate: params[:low_success_rate]) %>
 </section>
 <%= render partial: 'puzzles_table', locals: { puzzles: @archived_puzzles, actions: :archived } %>

--- a/test/models/puzzle_test.rb
+++ b/test/models/puzzle_test.rb
@@ -68,13 +68,13 @@ class PuzzleTest < ActiveSupport::TestCase
     assert_includes puzzles, puzzle1
     assert_includes puzzles, puzzle2
 
-    puzzle3 = puzzle1.clone
+    puzzle3 = puzzle1.clone_puzzle
     puzzles = Puzzle.without_cloned
     assert_not_includes puzzles, puzzle1
     assert_includes puzzles, puzzle2
     assert_includes puzzles, puzzle3
 
-    puzzle4 = puzzle3.clone
+    puzzle4 = puzzle3.clone_puzzle
     puzzles = Puzzle.without_cloned
     assert_not_includes puzzles, puzzle1
     assert_includes puzzles, puzzle2

--- a/test/models/puzzle_test.rb
+++ b/test/models/puzzle_test.rb
@@ -59,4 +59,26 @@ class PuzzleTest < ActiveSupport::TestCase
     assert_includes puzzles, puzzles(:archived_low_rate)
     assert_not_includes puzzles, puzzles(:archived_high_rate)
   end
+
+  test "without_cloned returns puzzles that has not been cloned" do
+    puzzle1 = puzzles(:one)
+    puzzle2 = puzzles(:two)
+
+    puzzles = Puzzle.without_cloned
+    assert_includes puzzles, puzzle1
+    assert_includes puzzles, puzzle2
+
+    puzzle3 = puzzle1.clone
+    puzzles = Puzzle.without_cloned
+    assert_not_includes puzzles, puzzle1
+    assert_includes puzzles, puzzle2
+    assert_includes puzzles, puzzle3
+
+    puzzle4 = puzzle3.clone
+    puzzles = Puzzle.without_cloned
+    assert_not_includes puzzles, puzzle1
+    assert_includes puzzles, puzzle2
+    assert_not_includes puzzles, puzzle3
+    assert_includes puzzles, puzzle4
+  end
 end


### PR DESCRIPTION
This PR adds a new feature to filter out already cloned puzzles from the archived table.

Currently there's no way to easily see which puzzles are already cloned, which makes it hard to know which ones should be cloned.

I'll add a few comments in the diff too