### PR TITLE
[IIRR-41] Preserve filters when cloning archived puzzle

### DIFF
--- a/app/controllers/puzzles/clones_controller.rb
+++ b/app/controllers/puzzles/clones_controller.rb
@@ -4,9 +4,9 @@ class Puzzles::ClonesController < ApplicationController
     cloned_puzzle = original_puzzle.clone_puzzle
 
     if cloned_puzzle.persisted?
-      redirect_to puzzles_path, notice: "Puzzle cloned. You can now edit the new puzzle."
+      redirect_back fallback_location: puzzles_path, notice: "Puzzle cloned. You can now edit the new puzzle."
     else
-      redirect_to puzzles_path, alert: "Failed to clone puzzle."
+      redirect_back fallback_location: puzzles_path, alert: "Failed to clone puzzle."
     end
   end
 end

--- a/test/controllers/puzzles/clones_controller_test.rb
+++ b/test/controllers/puzzles/clones_controller_test.rb
@@ -22,6 +22,16 @@ class Puzzles::ClonesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "pending", cloned.state
   end
 
+  test "redirects back to referer to preserve filters" do
+    original = puzzles(:one)
+    referer = puzzles_path(hide_cloned_puzzles: true, low_success_rate: true)
+
+    sign_in
+    post puzzle_clone_path(original), headers: { "HTTP_REFERER" => referer }
+
+    assert_redirected_to referer
+  end
+
   test "does not allow unauthenticated users to create a clone" do
     original = puzzles(:one)
 


### PR DESCRIPTION
## Summary
- Clone action on archived puzzles redirected to the bare index, dropping the active filters (`low_success_rate`, `hide_cloned_puzzles`) and forcing the user to re-apply them between clones.
- Swap `redirect_to puzzles_path` for `redirect_back fallback_location: puzzles_path` in `Puzzles::ClonesController#create` so the user lands back on the same filtered view.

## Test plan
- [x] `bin/rails test test/controllers/puzzles/clones_controller_test.rb`
- [x] Manually: enable a filter on Archived Puzzles, click Clone, confirm filter still applied.
