### PR TITLE
IIRR-34: Fix newlines around codeblocks for Redcarpet renderer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,6 +125,10 @@ td:last-child {
   width: 120px;
 }
 
+td pre {
+  margin-bottom: 1rem;
+}
+
 /* Banner styles - using styleguide colors where possible */
 .banner {
   position: fixed;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
     # fixing this at render because it's not really required by Discord
     # it's just a quirk of Redcarpet
     if text.match?(/[^\n]\n```(.*)\n```/m)
-      text = text.gsub(/[^\n]\n```(.*)\n```/m, "\n\n```\\1\n```")
+      text = text.gsub(/([^\n])\n```(.*?)\n```/m, "\\1\n\n```\\2\n```")
     end
 
     markdown.render(text.to_s).html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,14 @@ module ApplicationHelper
   def markdown(text)
     renderer = Redcarpet::Render::HTML.new(escape_html: true)
     markdown = Redcarpet::Markdown.new(renderer, fenced_code_blocks: true)
+
+    # Redcarpet needs the codeblocks to have 2 newlines before them
+    # fixing this at render because it's not really required by Discord
+    # it's just a quirk of Redcarpet
+    if text.match?(/[^\n]\n```(.*)\n```/m)
+      text = text.gsub(/[^\n]\n```(.*)\n```/m, "\n\n```\\1\n```")
+    end
+
     markdown.render(text.to_s).html_safe
   end
 end

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -24,4 +24,18 @@ class MarkdownHelperTest < ActionView::TestCase
 
     assert_includes as_html, "<pre><code>class ACodeBlock"
   end
+
+  test "fixes newlines around code blocks" do
+    puzzle_content = <<~CONTENT
+    Some content with
+    ```
+    class ACodeBlock
+    end
+    ```
+    in it
+    CONTENT
+    as_html = markdown(puzzle_content)
+
+    assert_includes as_html, "<pre><code>class ACodeBlock"
+  end
 end

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -36,6 +36,6 @@ class MarkdownHelperTest < ActionView::TestCase
     CONTENT
     as_html = markdown(puzzle_content)
 
-    assert_includes as_html, "<pre><code>class ACodeBlock"
+    assert_includes as_html, "with</p>\n\n<pre><code>class ACodeBlock"
   end
 end


### PR DESCRIPTION
My previous PR https://github.com/fastruby/ruby_or_rails/pull/93 adding code style introduced a bug: redcarpets needs the first three-backticks of a codeblock to have 2 newlines before it to render it properly.

This is not required for the closing three-backticks and also not required by discord either.

Because of this, some of our puzzles that don't have 2 newlines before the start of a codeblock were rendered incorrectly, parsing the code that should have been part of a code block as HTML instead.

This PR fixes that by fixing the missing newline during render if needed.

I didn't add a fix in the data stored in the database because it's not really a requirement for Discord, it's just a weird thing with Redcarpet so it's fixed on the fly as needed when rendered.

I also added a bit of space after the code block because it looked too close to the next line because of how redcarpet renders `pre` and `p` tags