### PR TITLE
IIRR-38: Collapse Rejected table by default, move to the bottom

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -129,6 +129,15 @@ td pre {
   margin-bottom: 1rem;
 }
 
+.rejected_table {
+  summary {
+    display: list-item;
+    text-align: start;
+    padding-inline-start: 1rem;
+  }
+  padding-block: 2rem;
+}
+
 /* Banner styles - using styleguide colors where possible */
 .banner {
   position: fixed;

--- a/app/views/puzzles/index.html.erb
+++ b/app/views/puzzles/index.html.erb
@@ -11,9 +11,6 @@
 </h1>
 <%= render partial: 'puzzles_table', locals: { puzzles: @approved_puzzles, actions: :approved } %>
 
-<h1>Rejected Puzzles</h1>
-<%= render partial: 'puzzles_table', locals: { puzzles: @rejected_puzzles, actions: :rejected } %>
-
 <h1>Archive Puzzles - Total: <%= @archived_puzzles.length %></h1>
 <p>These puzzles have already been sent to the users.</p>
 <section class="filters">
@@ -24,3 +21,9 @@
   <%= link_to "Hide cloned puzzles", url_for(hide_cloned_puzzles: true, low_success_rate: params[:low_success_rate]) %>
 </section>
 <%= render partial: 'puzzles_table', locals: { puzzles: @archived_puzzles, actions: :archived } %>
+
+<details class="rejected_table">
+  <summary>Click to expand/collapse "Rejected Puzzles" table</summary>
+  <h1>Rejected Puzzles</h1>
+  <%= render partial: 'puzzles_table', locals: { puzzles: @rejected_puzzles, actions: :rejected } %>
+</details>


### PR DESCRIPTION
This PR does 2 things:
- move the Rejected Puzzles table to the bottom
- put it inside a collapsible element (collapsed by default)

The motivation for these 2 changes is that the Rejected Puzzles table is not that useful and it's in the middle of the other useful tables.

As that table grows it makes it longer to get to the archived puzzles table which is more relevant from clonning.

<img width="413" height="92" alt="image" src="https://github.com/user-attachments/assets/f3d8a601-617b-4e12-84ce-42a31e6a7195" />
<img width="804" height="241" alt="image" src="https://github.com/user-attachments/assets/e112192f-ebc5-4af5-b957-0320e2b6132b" />

I didn't really add tests for this because it feels like testing implementation, collapsing/expanding is just native `<details>` tag default behavior.

QA:
Scroll to the bottom of the page, you'll see the element to expand/collapse the table.