### PR TITLE
Remove "Un-Archive" action, prevent un-archiving

### DIFF
--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -9,6 +9,8 @@ class Puzzle < ApplicationRecord
 
   scope :archived, -> { where(state: :archived).order(sent_at: :desc) }
 
+  validate :cannot_be_unarchived
+
   def correct_answer_percentage
     total = answers.size
     return 0 if total.zero?
@@ -31,5 +33,11 @@ class Puzzle < ApplicationRecord
   def self.without_cloned
     cloned_puzzles_ids = unscoped.where.not(original_puzzle_id: nil).pluck(:original_puzzle_id)
     where.not(id: cloned_puzzles_ids)
+  end
+
+  private
+
+  def cannot_be_unarchived
+    errors.add(:state, "cannot be unarchived") if state != state_was && state_was == "archived"
   end
 end

--- a/app/views/puzzles/_puzzles_table.html.erb
+++ b/app/views/puzzles/_puzzles_table.html.erb
@@ -43,7 +43,6 @@
             <%= button_to 'Approve', puzzle_state_path(puzzle, state: :approved), method: :patch, form_class: 'inline-form', class: 'btn approve-btn' %>
             <%= button_to 'Pending', puzzle_state_path(puzzle, state: :pending), method: :patch, form_class: 'inline-form', class: 'btn pending-btn' %>
           <% elsif actions == :archived %>
-            <%= button_to 'Un-Archive', puzzle_state_path(puzzle, state: :pending), method: :patch, form_class: 'inline-form', class: 'btn pending-btn' %>
             <%= button_to 'Clone', puzzle_clone_path(puzzle, state: :pending), method: :post, form_class: 'inline-form', class: 'btn pending-btn' %>
           <% end %>
         </td>

--- a/test/models/puzzle_test.rb
+++ b/test/models/puzzle_test.rb
@@ -81,4 +81,17 @@ class PuzzleTest < ActiveSupport::TestCase
     assert_not_includes puzzles, puzzle3
     assert_includes puzzles, puzzle4
   end
+
+  test "once archived, it cannot be unarchived" do
+    puzzle = puzzles(:archived_low_rate)
+    assert puzzle.valid?
+
+    refute puzzle.update(state: :pending)
+    refute puzzle.update(state: :approved)
+    refute puzzle.update(state: :rejected)
+
+    assert_raises(ActiveRecord::RecordInvalid, match: /State cannot be unarchived/) { puzzle.pending! }
+    assert_raises(ActiveRecord::RecordInvalid, match: /State cannot be unarchived/) { puzzle.approved! }
+    assert_raises(ActiveRecord::RecordInvalid, match: /State cannot be unarchived/) { puzzle.rejected! }
+  end
 end


### PR DESCRIPTION
This PR removes the "UN-ARCHIVE" button from the "Archived" table.

Changing the state out of "archived" can create many problems and it's not really used in practice.

I also added some validations to prevent changing the state when it was already "archived" to avoid mistakes. The state could of course be changed out of "archived" by skipping validations, but we can't prevent that.