### PR TITLE
Bump brakeman 8.0.4 -> 8.0.5 to fix scan_ruby CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## Why

`bin/brakeman` unshifts `--ensure-latest` onto ARGV, so brakeman exits non-zero whenever the locked version trails the latest release. The locked `8.0.4` is behind the published `8.0.5`, so the `scan_ruby` CI job has been failing on every open PR (independent of each PR's actual change).

## What

`bundle update brakeman` -> `8.0.5`. Only `Gemfile.lock` changes.

## Verification

`bin/brakeman --no-pager` exits 0 locally with 0 security warnings.

This unblocks Step 0 of the dependency merge plan so the rest of the Dependabot PRs can be evaluated against green CI.