### PR TITLE
Ignore generated app/assets/builds output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore compiled CSS output from dartsass-rails (regenerated on assets:precompile).
+/app/assets/builds/*
+!/app/assets/builds/.keep


### PR DESCRIPTION
## Summary

Add `app/assets/builds/` compiled output to `.gitignore`.

`dartsass-rails` compiles `app/assets/stylesheets/application.scss` into `app/assets/builds/application.css`, which is regenerated on every `assets:precompile`. It's a build artifact, the CSS equivalent of `/public/assets` (already ignored), but it was neither tracked nor ignored, so it showed up as untracked noise (`?? app/assets/builds/`) and could be committed by accident.

## Changes

- `.gitignore`: ignore `/app/assets/builds/*`, keep `!/app/assets/builds/.keep`.
- Add tracked `app/assets/builds/.keep` so the directory survives a fresh clone (dartsass needs it as its build target).

## Verification

- `git check-ignore app/assets/builds/application.css` now matches (ignored).
- `git status` is clean of the `app/assets/builds/` untracked entry.
