### PR TITLE
Pin minitest below 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "minitest", "< 6" # minitest 6 breaks Rails 8.0.2's test runner (line_filtering arity)
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,6 +558,7 @@ DEPENDENCIES
   fastruby-styleguide!
   importmap-rails
   jbuilder
+  minitest (< 6)
   omniauth
   omniauth-google-oauth2
   pg (~> 1.6.3)


### PR DESCRIPTION
## Summary

Pin `minitest < 6`. minitest 6 is incompatible with Rails 8.0.2's test runner and breaks the suite on boot.

## Root cause

minitest 6 restructured its runner. The per-method runner is now `Minitest::Runnable.run(klass, method_name, reporter)` (3 args) — in minitest 5 that was `run_one_method`, while `run(reporter, options)` was the suite-level runner (2 args).

Rails 8.0.2's `Rails::LineFiltering#run(reporter, options = {})` override was written against the old 2-arg shape. Under minitest 6, `run_suite` calls `run(self, method_name, reporter)`, hitting that 1..2-arity override and raising:

```
ArgumentError: wrong number of arguments (given 3, expected 1..2)
  railties-8.0.2/lib/rails/test_unit/line_filtering.rb:7:in 'run'
```

before any test runs.

## Why pin instead of fix forward

The fix lives in railties' `line_filtering.rb`, not our app. Adopting minitest 6 requires a Rails release that supports it (8.1+), which is beyond our `rails ~> 8.0.2` pin and belongs in a dedicated Rails upgrade. A standalone app-side monkeypatch would mean re-implementing line filtering against minitest 6 internals — fragile and not worth it.

## Impact

Without this pin, Dependabot re-resolutions keep pulling minitest 6.0.6 and red-flagging the `test` job across every batch of dependency PRs (4 open PRs are currently red for exactly this reason). Pinning makes the "upgrade to latest compatible" strategy safe.

## Follow-up

Revisit minitest 6 as part of a future Rails 8.1 upgrade, then drop this pin.

## Verification

- `bundle lock` keeps minitest at 5.25.5.
- Full test suite: 33 runs, 101 assertions, 0 failures, 0 errors.
