### PR TITLE
Run Dependabot weekly and group minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Bundle all minor + patch gem updates into a single weekly PR.
+      # Major bumps still open as individual PRs for deliberate review.
+      ruby-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Reduce Dependabot noise: run **weekly** instead of daily, and **group** minor/patch updates into a single PR per ecosystem.

## Changes to `.github/dependabot.yml`

- `schedule.interval`: `daily` → `weekly` (Mondays) for both bundler and github-actions.
- Add a `groups` block per ecosystem bundling **minor + patch** updates into one PR.
- Major bumps remain **individual PRs** for deliberate one-at-a-time review.
- `open-pull-requests-limit`: `10` → `5`.

## Why

Daily updates produced large batches of individual PRs (10+ at a time). Weekly + grouping collapses the routine minor/patch churn into a single reviewable PR, while keeping majors separate so breaking changes still get scrutinized on their own.

## Notes / future options

- To stop receiving major-bump PRs entirely (and handle majors manually), add an `ignore` entry with `update-types: ["version-update:semver-major"]`.
- A specific run time/timezone can be pinned via `schedule.time` / `schedule.timezone`.
