### PR TITLE
Exclude Rails from the Dependabot minor/patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       # Bundle all minor + patch gem updates into a single weekly PR.
       # Major bumps still open as individual PRs for deliberate review.
       ruby-minor-and-patch:
+        # Keep the Rails framework out of the routine batch: a Rails minor
+        # (e.g. 8.0 -> 8.1) is a deliberate upgrade, not routine churn, and
+        # should arrive as its own PR.
+        exclude-patterns:
+          - "rails"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Summary

Add `exclude-patterns: ["rails"]` to the `ruby-minor-and-patch` group so Rails framework bumps are **not** batched with routine gems.

## Why

PR #115 grouped a **Rails 8.0.2 → 8.1.3** framework upgrade together with patch-level gems (solid_cache, web-console, discordrb, omniauth-google-oauth2), because 8.0→8.1 is a semver "minor." A Rails minor is a deliberate upgrade that warrants its own PR and review, not routine churn.

With this change, Rails bumps open as individual PRs; all other minor/patch gems continue to batch weekly.

## Follow-up context

#115 was closed and split into #117 (Rails 8.1.3) and #118 (the routine gems).